### PR TITLE
feat: ignore unreachable branch to improve branch coverage precision

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,6 @@
 /transform/*.mjs
 /tests/ts/fixture
 /third_party
-/tests/cpp/lit/**/*.json
+/tests/cpp/lit/expectInstrument**/*.json
 /.cache
 /.github/CODEOWNERS

--- a/instrumentation/BasicBlockWalker.hpp
+++ b/instrumentation/BasicBlockWalker.hpp
@@ -167,7 +167,7 @@ private:
   ///
   /// @brief remove empty block that do not belong to any branch
   ///
-  void unlinkEmptyBlock() noexcept;
+  void cleanBlock() noexcept;
 };
 } // namespace wasmInstrumentation
 

--- a/tests/cpp/lit/covInstrument/unreachable.wast
+++ b/tests/cpp/lit/covInstrument/unreachable.wast
@@ -1,0 +1,49 @@
+(module
+ (type $0 (func (param i32 i32 i32 i32)))
+ (type $1 (func (param i32)))
+ (type $2 (func))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (global $~lib/memory/__data_end i32 (i32.const 76))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 32844))
+ (global $~lib/memory/__heap_base i32 (i32.const 32844))
+ (memory $0 1)
+ (data $0 (i32.const 12) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\"\00\00\00a\00s\00s\00e\00m\00b\00l\00y\00/\00i\00n\00d\00e\00x\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00")
+ (table $0 1 1 funcref)
+ (elem $0 (i32.const 1))
+ (export "main" (func $assembly/index/main))
+ (export "memory" (memory $0))
+ (func $assembly/index/f (param $a i32)
+  ;;@ assembly/index.ts:5:2
+  (if
+   ;;@
+   (i32.eqz
+    ;;@ assembly/index.ts:5:9
+    (i32.ge_s
+     (local.get $a)
+     ;;@ assembly/index.ts:5:14
+     (i32.const 10)
+    )
+   )
+   (then
+    ;;@
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 32)
+     (i32.const 5)
+     (i32.const 3)
+    )
+    ;;@
+    (unreachable)
+   )
+  )
+ )
+ (func $assembly/index/main
+  ;;@ assembly/index.ts:2:2
+  (call $assembly/index/f
+   ;;@ assembly/index.ts:2:4
+   (i32.const 10)
+  )
+  ;;@ assembly/index.ts:2:2
+ )
+ ;; custom section "sourceMappingURL", size 17
+)

--- a/tests/cpp/lit/covInstrument/unreachable.wast.debug.json
+++ b/tests/cpp/lit/covInstrument/unreachable.wast.debug.json
@@ -1,0 +1,27 @@
+{
+  "debugFiles": ["assembly/index.ts"],
+  "debugInfos": {
+    "assembly/index/f": {
+      "branchInfo": [],
+      "index": 0,
+      "lineInfo": [
+        [
+          [0, 5, 2],
+          [0, 5, 9],
+          [0, 5, 14]
+        ],
+        []
+      ]
+    },
+    "assembly/index/main": {
+      "branchInfo": [],
+      "index": 1,
+      "lineInfo": [
+        [
+          [0, 2, 2],
+          [0, 2, 4]
+        ]
+      ]
+    }
+  }
+}

--- a/tests/cpp/lit/covInstrument/unreachable.wast.run.log
+++ b/tests/cpp/lit/covInstrument/unreachable.wast.run.log
@@ -1,0 +1,6 @@
+make directly call to function index=1
+make directly call to function index=0
+basic block entry trace to: function=0, basic block=0
+basic block entry trace to: function=0, basic block=1
+basic block entry trace to: function=1, basic block=0
+exit from function call index=0


### PR DESCRIPTION
In AS test, we definitely do not want to touch unreachable branch. And since unreachable will fail the execution and result output, it does not make sure to statistic unreachable branch coverage
This PR remove the basic blocks which must unreachable.

Part of #4.
