### PR TITLE
Added `flags` option to the precompile step

### DIFF
--- a/src/core/precompile.ts
+++ b/src/core/precompile.ts
@@ -57,17 +57,10 @@ export function getRelatedFiles(includes: string[], excludes: string[], filter: 
 }
 
 async function transform(sourceCodePath: string, transformFunction: string, flags: string) {
-  let ascArgv = [
-      sourceCodePath,
-      "--noEmit",
-      "--disableWarning",
-     "--transform",
-      transformFunction,
-      "-O0",
-  ]
+  let ascArgv = [sourceCodePath, "--noEmit", "--disableWarning", "--transform", transformFunction, "-O0"];
   if (flags) {
-      const argv = flags.split(" ");
-      ascArgv = ascArgv.concat(argv);
+    const argv = flags.split(" ");
+    ascArgv = ascArgv.concat(argv);
   }
   const { error, stderr } = await main(ascArgv);
   if (error) {

--- a/src/core/precompile.ts
+++ b/src/core/precompile.ts
@@ -14,6 +14,7 @@ export async function precompile(
   includes: string[],
   excludes: string[],
   testcases: string[] | undefined,
+  flags: string,
   transformFunction = join(projectRoot, "transform", "listFunctions.mjs")
 ): Promise<UnittestPackage> {
   // if specify testcases, use testcases for unittest
@@ -23,7 +24,7 @@ export async function precompile(
   const sourceCodePaths = getRelatedFiles(includes, excludes, (path: string) => !path.endsWith(".test.ts"));
   const sourceCodeTransforms: Promise<void>[] = [];
   for (const sourceCodePath of sourceCodePaths.values()) {
-    sourceCodeTransforms.push(transform(sourceCodePath, transformFunction));
+    sourceCodeTransforms.push(transform(sourceCodePath, transformFunction, flags));
   }
   await Promise.all(sourceCodeTransforms);
 
@@ -55,15 +56,20 @@ export function getRelatedFiles(includes: string[], excludes: string[], filter: 
   return result;
 }
 
-async function transform(sourceCodePath: string, transformFunction: string) {
-  const { error, stderr } = await main([
-    sourceCodePath,
-    "--noEmit",
-    "--disableWarning",
-    "--transform",
-    transformFunction,
-    "-O0",
-  ]);
+async function transform(sourceCodePath: string, transformFunction: string, flags: string) {
+  let ascArgv = [
+      sourceCodePath,
+      "--noEmit",
+      "--disableWarning",
+     "--transform",
+      transformFunction,
+      "-O0",
+  ]
+  if (flags) {
+      const argv = flags.split(" ");
+      ascArgv = ascArgv.concat(argv);
+  }
+  const { error, stderr } = await main(ascArgv);
   if (error) {
     // eslint-disable-next-line @typescript-eslint/no-base-to-string
     console.error(stderr.toString());

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export type OutputMode = "html" | "json" | "table";
 export async function start_unit_test(fo: FileOption, to: TestOption, oo: OutputOption): Promise<boolean> {
   emptydirSync(oo.outputFolder);
   emptydirSync(oo.tempFolder);
-  const unittestPackage = await precompile(fo.includes, fo.excludes, fo.testcases);
+  const unittestPackage = await precompile(fo.includes, fo.excludes, fo.testcases, to.flags);
   console.log(chalk.blueBright("code analysis: ") + chalk.bold.greenBright("OK"));
   const wasmPaths = await compile(unittestPackage.testCodePaths, oo.tempFolder, to.flags);
   console.log(chalk.blueBright("compile testcases: ") + chalk.bold.greenBright("OK"));

--- a/tests/ts/test/core/precompile.test.ts
+++ b/tests/ts/test/core/precompile.test.ts
@@ -4,7 +4,7 @@ import { projectRoot } from "../../../../src/utils/projectRoot.js";
 
 test("listFunction transform", async () => {
   const transformFunction = join(projectRoot, "transform", "listFunctions.mjs");
-  const unittestPackages = await precompile(["tests/ts/fixture/transformFunction.ts"], [], [], transformFunction);
+  const unittestPackages = await precompile(["tests/ts/fixture/transformFunction.ts"], [], [], "", transformFunction);
   expect(unittestPackages.testCodePaths).toEqual([]);
   expect(unittestPackages.sourceFunctions).toMatchSnapshot();
 });

--- a/tests/ts/test/core/throwError.test.ts
+++ b/tests/ts/test/core/throwError.test.ts
@@ -20,7 +20,7 @@ test("transform error", async () => {
   const transformFunction = join(projectRoot, "transform", "listFunctions.mjs");
   expect(jest.isMockFunction(main)).toBeTruthy();
   await expect(async () => {
-    await precompile(["tests/ts/fixture/transformFunction.ts"], [], [], transformFunction);
+    await precompile(["tests/ts/fixture/transformFunction.ts"], [], [], "", transformFunction);
   }).rejects.toThrow("mock asc.main() error");
 });
 


### PR DESCRIPTION
The current implementation doesn't import the flags into the `precompile` step. This is a bit annoying when the main compilation requires the usage of `--path` to link different packages.

Let me know if this looks OK.