### PR TITLE
refactor: merge Promise.all inside and outside of executor

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "isolatedModules": true
   },
   "include": ["src/**/*.ts", "transform", "tests/ts/**/*.ts"],
   "exclude": ["assembly", "example"]


### PR DESCRIPTION
2 layers promise make code hard to understand and refactor
