### PR TITLE
fix: do transform for all files when precompile

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,4 +7,9 @@ export default [
     ],
   },
   ...baseConfig,
+  {
+    rules: {
+      "unicorn/no-array-for-each": "off",
+    },
+  },
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ import { generateReport, reportConfig } from "./generator/index.js";
 import { TestOption } from "./interface.js";
 import { join } from "node:path";
 import { CompilationError } from "./utils/ascWrapper.js";
-import assert from "node:assert";
 
 const { readFileSync, emptydirSync } = pkg;
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -77,7 +77,6 @@ export class Parser {
         this.functionCovTraceMap.set(name, originTraces.concat(traces));
       }
       const lineInfoMap: LineInfoMap = new Map();
-      // eslint-disable-next-line unicorn/no-array-for-each
       info.lineInfo.forEach((ranges: LineRange | null, index: number) => {
         // If instrument return basic block == null, ignore it.
         if (ranges === null) return;

--- a/src/type/global.d.ts
+++ b/src/type/global.d.ts
@@ -3,8 +3,10 @@ import { SourceFunctionInfo } from "../interface.ts";
 declare global {
   // why use var: [Remove block-scoped bindings from globalThis](https://github.com/microsoft/TypeScript/issues/30547)
   // store listFunctions transform results in global
+  // eslint-disable-next-line no-var
   var __functionInfos: Map<string, SourceFunctionInfo[]> | undefined;
   // store listTestNames transform results in global
+  // eslint-disable-next-line no-var
   var testNames: string[];
 }
 

--- a/transform/listFunctions.mts
+++ b/transform/listFunctions.mts
@@ -64,12 +64,14 @@ class SourceFunctionTransform extends Transform {
     // There will be two sources with SourceKind.UserEntry, ~lib/rt/index-incremental.ts should be filtered
     program.sources
       .filter((source) => source.sourceKind === SourceKind.UserEntry && !source.normalizedPath.startsWith("~lib/"))
-      .map((source) => {
+      .forEach((source) => {
         this.functionInfos = [];
         this.visitNode(source);
         this.functionInfos.reverse();
-        globalThis.__functionInfos = globalThis.__functionInfos || new Map<string, SourceFunctionInfo[]>();
-        globalThis.__functionInfos.set(source.normalizedPath, this.functionInfos);
+        const functionInfos =
+          (globalThis.__functionInfos as Map<string, SourceFunctionInfo[]>) || new Map<string, SourceFunctionInfo[]>();
+        functionInfos.set(source.normalizedPath, this.functionInfos);
+        globalThis.__functionInfos = functionInfos;
       });
     throw new Error("TransformDone");
   }


### PR DESCRIPTION
It will reduce the complexity of precompiler from O(n^2) to O(n)
part of #69